### PR TITLE
fix: function name error & openssl 3.6 compiling error in centos 9

### DIFF
--- a/service/nginx.sh
+++ b/service/nginx.sh
@@ -291,7 +291,7 @@ function _install() {
     case "$(_os)" in # 根据操作系统类型进行分支处理
     centos)
         # 检查是否使用 dnf 包管理器 (较新版本 CentOS/Fedora)
-        if _exists "dnf"; then
+        if cmd_exists "dnf"; then
             # 添加必要的 dnf 插件和 EPEL 源
             packages_name="dnf-plugins-core epel-release epel-next-release ${packages_name}"
             installed_packages="$(dnf list installed 2>/dev/null)" # 获取已安装包列表
@@ -436,7 +436,7 @@ function compile_dependencies() {
     case "$(_os)" in
     centos)
         # 安装 CentOS 特定的工具和开发库
-        _install bind-utils gcc-c++ perl-IPC-Cmd perl-Getopt-Long perl-Data-Dumper
+        _install bind-utils gcc-c++ perl-IPC-Cmd perl-Getopt-Long perl-Data-Dumper perl-Time-Piece
         _install pcre2-devel zlib-devel libxml2-devel libxslt-devel gd-devel geoip-devel perl-ExtUtils-Embed gperftools-devel perl-devel brotli-devel
         # 检查并安装 Perl 模块 FindBin
         if ! perl -e "use FindBin" &>/dev/null; then


### PR DESCRIPTION
[信息] 正在执行命令: make -j1
make -f objs/Makefile
make[1]: Entering directory '/usr/local/xray-script/nginxtemp.obm4fWA6/nginx-1.29.4'
cd ../openssl-openssl-3.6.0 \
&& if [ -f Makefile ]; then make clean; fi \
&& ./config --prefix=/usr/local/xray-script/nginxtemp.obm4fWA6/nginx-1.29.4/../openssl-openssl-3.6.0/.openssl no-shared no-threads -g0 -O3 -fstack-reuse=all -fdwarf2-cfi-asm -fplt -fno-trapv -fno-exceptions -fno-unwind-tables -fno-asynchronous-unwind-tables -fno-stack-check -fno-stack-clash-protection -fno-stack-protector -fcf-protection=none -fno-split-stack -fno-sanitize=all -fno-instrument-functions \
&& make \
&& make install_sw LIBDIR=lib
Configuring OpenSSL version 3.6.0 for target linux-x86_64
Using os-specific seed configuration
Created configdata.pm
Running configdata.pm
Created Makefile.in
Can't locate Time/Piece.pm in @INC (you may need to install the Time::Piece module) (@INC contains: . /usr/local/xray-script/nginxtemp.obm4fWA6/openssl-openssl-3.6.0/Configurations /usr/local/xray-script/nginxtemp.obm4fWA6/openssl-openssl-3.6.0/util/perl /usr/local/lib64/perl5/5.32 /usr/local/share/perl5/5.32 /usr/lib64/perl5/vendor_perl /usr/share/perl5/vendor_perl /usr/lib64/perl5 /usr/share/perl5 /usr/local/xray-script/nginxtemp.obm4fWA6/openssl-openssl-3.6.0/external/perl/Text-Template-1.56/lib) at Makefile.in line 37.
BEGIN failed--compilation aborted at Makefile.in line 37.
make[1]: *** [objs/Makefile:2285: ../openssl-openssl-3.6.0/.openssl/include/openssl/ssl.h] Error 1
make[1]: Leaving directory '/usr/local/xray-script/nginxtemp.obm4fWA6/nginx-1.29.4'
make: *** [Makefile:10: build] Error 2
[错误] 执行命令 (make -j1) 失败，请检查并重试。

centos 9